### PR TITLE
Check for "trusted.gpg" before using "apt-key"

### DIFF
--- a/debian/pgdg-keyring.postinst
+++ b/debian/pgdg-keyring.postinst
@@ -7,7 +7,7 @@ KEYRING="/etc/apt/trusted.gpg.d/apt.postgresql.org.gpg"
 case $1 in
 	configure)
 		# remove older copy of key, if any
-		if apt-key --keyring /etc/apt/trusted.gpg list 2>/dev/null | grep -q ACCC4CF8; then
+		if [ -f /etc/apt/trusted.gpg ] && apt-key --keyring /etc/apt/trusted.gpg list 2>/dev/null | grep -q ACCC4CF8; then
 			echo -n "Removing apt.postgresql.org key from trusted.gpg: "
 			apt-key --keyring /etc/apt/trusted.gpg remove ACCC4CF8
 		fi


### PR DESCRIPTION
In Stretch, `/etc/apt/trusted.gpg` doesn't exist by default, but using `apt-key` on it in the way that this package does will create it, and will do so with permissions that cause future runs of `apt-get update` to throw warnings:

    W: http://security.debian.org/dists/stretch/updates/InRelease: The key(s) in the keyring /etc/apt/trusted.gpg are ignored as the file is not readable by user '_apt' executing apt-key.
    W: http://apt.postgresql.org/pub/repos/apt/dists/stretch-pgdg/InRelease: The key(s) in the keyring /etc/apt/trusted.gpg are ignored as the file is not readable by user '_apt' executing apt-key.
    W: http://deb.debian.org/debian/dists/stretch-updates/InRelease: The key(s) in the keyring /etc/apt/trusted.gpg are ignored as the file is not readable by user '_apt' executing apt-key.
    W: http://deb.debian.org/debian/dists/stretch/Release.gpg: The key(s) in the keyring /etc/apt/trusted.gpg are ignored as the file is not readable by user '_apt' executing apt-key.

Checking for the existence of the file before invoking `apt-key` to check the contents solves the problem and stops this file from being accidentally created. :+1:

(https://github.com/docker-library/postgres/issues/357 is where this was noticed downstream and tracked down to this particular invocation of `apt-key` :smile:)

Happy to update, rebase, amend, adjust, etc as desired!