### PR TITLE
Update "gpg" invocations to use "--batch"

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -3,11 +3,11 @@
 KEYID = B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
 
 override_dh_auto_build:
-	gpg --import apt.postgresql.org.asc
-	gpg --import apt.postgresql.org.gpg
-	gpg --export -a $(KEYID) > apt.postgresql.org.asc
-	gpg --export $(KEYID) > apt.postgresql.org.gpg
-	gpg --keyring ./apt.postgresql.org.gpg --list-sigs $(KEYID)
+	gpg --batch --import apt.postgresql.org.asc
+	gpg --batch --import apt.postgresql.org.gpg
+	gpg --batch --export -a $(KEYID) > apt.postgresql.org.asc
+	gpg --batch --export $(KEYID) > apt.postgresql.org.gpg
+	gpg --batch --keyring ./apt.postgresql.org.gpg --list-sigs $(KEYID)
 
 %:
 	dh $@


### PR DESCRIPTION
See https://bugs.debian.org/913614

See also https://github.com/docker-library/postgres/pull/527 for where we're running into build failures due to this (so this will only affect us for architectures for which apt.postgresql.org doesn't include packages and we build from source instead).

I think the following tidbit from dkg was the most compelling (and is what convinced me to make a billion PRs today fixing this in about 100 places :sweat_smile:):

> PS i do encourage everyone who is automating the use of gpg to use --batch everywhere, as this forces GnuPG into a mode that is expected to be used for automation (its "API", for lack of a better term, as opposed to its "UI", which is its normal non-batch mode).  And, FWIW, i agree with Tianon that GnuPG should simply assume --batch if no tty exists, but that's not the kind of change i can fit into debian stable, i think.